### PR TITLE
Fix post ordering on blog index

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,12 @@
 ---
 const modules = import.meta.glob('../content/blog/*.md', { eager: true });
-const posts = Object.entries(modules).map(([path, post]) => {
-  const slug = path.split('/').pop().replace('.md','');
-  const { title, pubDate } = post.frontmatter;
-  return { slug, title, pubDate };
-});
+const posts = Object.entries(modules)
+  .map(([path, post]) => {
+    const slug = path.split('/').pop().replace('.md', '');
+    const { title, pubDate } = post.frontmatter;
+    return { slug, title, pubDate };
+  })
+  .sort((a, b) => new Date(b.pubDate).valueOf() - new Date(a.pubDate).valueOf());
 ---
 
 <main style="max-width:600px;margin:2rem auto;font-family:sans-serif;">


### PR DESCRIPTION
## Summary
- sort posts by `pubDate` so the blog index shows newer posts first

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e3aac4714832ba9ac1216c029e07c